### PR TITLE
Fixed 'no attribute data_completions' error when writing inside a tag.

### DIFF
--- a/tailwind_autocomplete.py
+++ b/tailwind_autocomplete.py
@@ -35,11 +35,6 @@ class tailwindCompletions(sublime_plugin.EventListener):
                 return self.class_completions
             else:
                 return []
-        elif view.match_selector(locations[0], "text.html meta.tag - text.html punctuation.definition.tag.begin"):
-
-            # Cursor is in a tag, but not inside an attribute, i.e. <div {here}>
-            return self.data_completions
-
         else:
 
             return []


### PR DESCRIPTION
This commit removes a legacy code since we don't have a `data_completions` variable.

p.s. Here is the source code of uikit where this variable came from https://github.com/uikit/uikit-sublime/blob/master/main.py#L12