### PR TITLE
Add .jsx Support

### DIFF
--- a/tailwind_autocomplete.py
+++ b/tailwind_autocomplete.py
@@ -9,7 +9,7 @@ class tailwindCompletions(sublime_plugin.EventListener):
         self.class_completions = [("%s \tTailwind Class" % s, s) for s in tailwind_classes]
 
     def on_query_completions(self, view, prefix, locations):
-        jsSources = ["source.js string.quoted", "source.ts string.quoted", "source.tsx string.quoted"]
+        jsSources = ["source.js string.quoted", "source.jsx string.quoted", "source.ts string.quoted", "source.tsx string.quoted"]
 
         matchHTMLString = view.match_selector(locations[0], "text.html string.quoted")
         matchJSString = next(filter(lambda source: view.match_selector(locations[0], source), jsSources), None)


### PR DESCRIPTION
### What? Why?
This tiny PR addresses Issue #14 - lack of .jsx support.

### Demo?
![jsxTailwindSublimeAutocomplete](https://user-images.githubusercontent.com/2800327/209602417-f72cc860-161d-4d47-ab70-2b6f40f6284e.gif)

### Adoption?
If you'd like to add this feature to your own Sublime installation without waiting for review, you can use this bash script:

```bash
git clone https://github.com/BernardFaucher/tailwind-sublime-autocomplete
mkdir ~/Library/Application\ Support/Sublime\ Text/Packages/tailwind-sublime-autocomplete
cp tailwind-sublime-autocomplete/tailwind_autocomplete.py ~/Library/Application\ Support/Sublime\ Text/Packages/tailwind-sublime-autocomplete/tailwind_autocomplete.py
rm -rf tailwind-sublime-autocomplete
```
cc: @BestSuperUser 